### PR TITLE
Texinfo overflow check + VS2017 compilation fixes.

### DIFF
--- a/common/polylib.c
+++ b/common/polylib.c
@@ -32,7 +32,7 @@ int	c_peak_windings;
 int	c_winding_allocs;
 int	c_winding_points;
 
-#define	BOGUS_RANGE	8192
+//#define	BOGUS_RANGE	8192 //mxd. Already defined in mathlib.h
 
 void pw(winding_t *w)
 {

--- a/common/qfiles.h
+++ b/common/qfiles.h
@@ -229,7 +229,8 @@ typedef struct miptex_s
 #define	MAX_MAP_BRUSHES		8192
 #define	MAX_MAP_ENTITIES	2048
 #define	MAX_MAP_ENTSTRING	0x40000
-#define	MAX_MAP_TEXINFO		8192
+#define	DEFAULT_MAP_TEXINFO	8192  //mxd: vanilla
+#define	MAX_MAP_TEXINFO		16384 //mxd: KMQ2
 
 #define	MAX_MAP_AREAS		256
 #define	MAX_MAP_AREAPORTALS	1024

--- a/qbsp3/qbsp3.c
+++ b/qbsp3/qbsp3.c
@@ -90,7 +90,7 @@ node_t	*BlockTree (int xl, int yl, int xh, int yh)
 		normal[1] = 0;
 		normal[2] = 0;
 		dist = mid*1024;
-		node->planenum = FindFloatPlane (normal, dist);
+		node->planenum = FindFloatPlane (normal, dist, 0);
 		node->children[0] = BlockTree ( mid, yl, xh, yh);
 		node->children[1] = BlockTree ( xl, yl, mid-1, yh);
 	}
@@ -101,7 +101,7 @@ node_t	*BlockTree (int xl, int yl, int xh, int yh)
 		normal[1] = 1;
 		normal[2] = 0;
 		dist = mid*1024;
-		node->planenum = FindFloatPlane (normal, dist);
+		node->planenum = FindFloatPlane (normal, dist, 0);
 		node->children[0] = BlockTree ( xl, mid, xh, yh);
 		node->children[1] = BlockTree ( xl, yl, xh, mid-1);
 	}

--- a/qbsp3/textures.c
+++ b/qbsp3/textures.c
@@ -124,6 +124,14 @@ void TextureAxisFromPlane(plane_t *pln, vec3_t xv, vec3_t yv)
 	VectorCopy (baseaxis[bestaxis*3+2], yv);
 }
 
+inline void CheckTexinfoCount() //mxd
+{
+	if (numtexinfo == DEFAULT_MAP_TEXINFO)
+		printf("WARNING: texinfo count exceeds vanilla limit (%i).\n", DEFAULT_MAP_TEXINFO);
+	else if (numtexinfo >= MAX_MAP_TEXINFO)
+		Error("ERROR: texinfo count exceeds program limit (%i).\n", MAX_MAP_TEXINFO);
+}
+
 // DarkEssence: function for new #mapversion with UVaxis
 int TexinfoForBrushTexture_UV (brush_texture_t *bt, vec_t *UVaxis)
 {
@@ -175,6 +183,7 @@ int TexinfoForBrushTexture_UV (brush_texture_t *bt, vec_t *UVaxis)
 	}
 	*tc = tx;
 	numtexinfo++;
+	CheckTexinfoCount(); //mxd
 
 	// load the next animation
 	mt = FindMiptex (bt->name);
@@ -319,6 +328,7 @@ skip:;
 	}
 	*tc = tx;
 	numtexinfo++;
+	CheckTexinfoCount(); //mxd
 
 	// load the next animation
 	mt = FindMiptex (bt->name);

--- a/qrad3/lightmap.c
+++ b/qrad3/lightmap.c
@@ -1165,7 +1165,7 @@ void FinalLightFace (int facenum)
 	int			i, j, k, st;
 	vec3_t		lb;
 	patch_t		*patch;
-	triangulation_t	*trian;
+	triangulation_t	*trian = NULL; //mxd. "Potentially uninitialized local pointer variable" error in VS2017 if uninitialized
 	facelight_t	*fl;
 	float		minlight;
 	float		max, newmax;


### PR DESCRIPTION
Increased texinfo limit to 16384 (matches KMQ2 limit).
Added texinfo overflow check.
Cosmetic changes to fix compilation errors in VS2017.