### PR TITLE
Add support for _falloff property on point lights. From blarghrad/arghrad.

### DIFF
--- a/4rad/lightmap.c
+++ b/4rad/lightmap.c
@@ -1340,6 +1340,11 @@ void CreateDirectLights (void)
         else
             dl->adjangle = 1.0f;
 
+        // [slipyx] add _falloff
+        dl->falloff = atoi(ValueForKey(e, "_falloff"));
+        if (dl->falloff < 0)
+            dl->falloff = 0;
+
         intensity = FloatForKey (e, "light");
         if (!intensity)
             intensity = FloatForKey (e, "_light");
@@ -1593,7 +1598,15 @@ static void LightContributionToPoint	(	directlight_t *l, vec3_t pos, int nodenum
         {
         case emit_point:
             // linear falloff
-            scale = (l->intensity - l->wait * dist) * dot;  //qb: wait
+            if (l->falloff == 0)
+                scale = (l->intensity - l->wait * dist) * dot;  //qb: wait
+            // [slipyx] additional falloff behavior, from zzsort/blarghrad
+            // inverse
+            else if (l->falloff == 1)
+                scale = l->intensity / dist * dot;
+            // inverse square
+            else
+                scale = l->intensity / (dist * dist) * dot;
             break;
 
         case emit_sky: //qb: sky radiosity

--- a/4rad/qrad.h
+++ b/4rad/qrad.h
@@ -48,6 +48,7 @@ typedef struct directlight_s
 	int			style;
     float       wait;
     float       adjangle;
+    int         falloff;
 	vec3_t		origin;
 	vec3_t		color;
 	vec3_t		normal;		// for surfaces and spotlights

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ radiosity
 *   Keep emit_surface active for sky planes when sun is active. Adjust with -sunradscale. (qbism)
 *   Use any existing TGA replacement textures for radiosity (AA tools)
 *   Spotlight center to surface point attenuation (AA tools)
+*   Add \_falloff property for point lights (blarghrad)
 *   Radiosity texture checking (GDD tools)
 *   Face extents (quemap)
 *   Edge lighting fix (qbism)	


### PR DESCRIPTION
Implemented just for point lights. 0 = linear, 1 = inverse, 2 = inverse square.
