### PR TITLE
do not use so much stack

### DIFF
--- a/4rad/4rad.c
+++ b/4rad/4rad.c
@@ -430,7 +430,6 @@ re_test:
 }
 
 void MakeTransfers(int32_t i) {
-
     int32_t j;
     vec3_t delta;
     vec_t dist, inv_dist = 0, scale;
@@ -440,7 +439,7 @@ void MakeTransfers(int32_t i) {
     float total, inv_total;
     dplane_t plane;
     vec3_t origin;
-    float transfers[MAX_PATCHES_QBSP];
+    float * transfers;//[MAX_PATCHES_QBSP];
     int32_t s;
     int32_t itotal;
     byte pvs[(MAX_MAP_LEAFS_QBSP + 7) / 8];
@@ -467,6 +466,9 @@ void MakeTransfers(int32_t i) {
     } else if (test_trace) {
         DecompressBytes(trace_buf_size, patch->trace_hit, trace_buf);
     }
+
+    transfers = malloc(sizeof(*transfers) * num_patches);
+
     for (j = 0, patch2 = patches; j < num_patches; j++, patch2++) {
         transfers[j] = 0;
 
@@ -573,6 +575,9 @@ void MakeTransfers(int32_t i) {
 
     // don't bother locking around this.  not that important.
     total_transfer += patch->numtransfers;
+
+// cleanup:
+    free(transfers);
 }
 
 /*
@@ -833,8 +838,10 @@ light modelfile
 int32_t main(int32_t argc, char **argv) {
     int32_t i;
     double start, end;
-    char name[1060];
-    char tgamedir[1024] = "", tbasedir[1024] = "", tmoddir[1024] = "";
+    char * name;
+    char * tgamedir = "";
+    char * tbasedir = "";
+    char * tmoddir = "";
 
     printf("\n\n<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< 4rad >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>\n");
     printf("radiosity compiler build " __DATE__ "\n");
@@ -914,13 +921,13 @@ int32_t main(int32_t argc, char **argv) {
 
         // qb:  set gamedir, moddir, and basedir
         else if (!strcmp(argv[i], "-gamedir")) {
-            strcpy(tgamedir, argv[i + 1]);
+            tgamedir = argv[i + 1];
             i++;
         } else if (!strcmp(argv[i], "-basedir")) {
-            strcpy(tbasedir, argv[i + 1]);
+            tbasedir = argv[i + 1];
             i++;
         } else if (!strcmp(argv[i], "-moddir")) {
-            strcpy(tmoddir, argv[i + 1]);
+            tmoddir = argv[i + 1];
             i++;
         }
 
@@ -1061,7 +1068,7 @@ int32_t main(int32_t argc, char **argv) {
     DefaultExtension(source, ".bsp");
 
     //	ReadLightFile ();
-
+    name = (char *)malloc(strlen(inbase) + strlen(source) + 1);
     sprintf(name, "%s%s", inbase, source);
     printf("reading %s\n", name);
     LoadBSPFile(name);

--- a/4rad/lightmap.c
+++ b/4rad/lightmap.c
@@ -216,7 +216,7 @@ void BuildFaceExtents(void) {
                         st_maxs[j] = val;
                     }
                 }
-   
+
             }
 
             for (i = 0; i < 3; i++) // calculate center
@@ -2172,8 +2172,8 @@ float sampleofs[5][2] =
     {{0, 0}, {-0.25, -0.25}, {0.25, -0.25}, {0.25, 0.25}, {-0.25, 0.25}};
 
 void BuildFacelights(int32_t facenum) {
-    lightinfo_t liteinfo[5];
-    float *styletable[MAX_LSTYLES];
+    lightinfo_t * liteinfo;//[5];
+    float **styletable;//[MAX_LSTYLES];
     int32_t i, j;
     float *spot;
     patch_t *patch;
@@ -2185,14 +2185,17 @@ void BuildFacelights(int32_t facenum) {
     vec3_t pos;
     vec3_t pointnormal;
 
+    liteinfo = malloc(sizeof(*liteinfo) * 5);
+    styletable = malloc(sizeof(*styletable) * MAX_LSTYLES);
+
     if (use_qbsp) {
         dface_tx *this_face;
         this_face = &dfacesX[facenum];
 
         if (texinfo[this_face->texinfo].flags & (SURF_WARP | SURF_SKY))
-            return; // non-lit texture
+            goto cleanup; // non-lit texture
 
-        memset(styletable, 0, sizeof(styletable));
+        memset(styletable, 0, sizeof(*styletable) * MAX_LSTYLES);
 
         if (extrasamples) // set with -extra option
             numsamples = 5;
@@ -2221,9 +2224,9 @@ void BuildFacelights(int32_t facenum) {
         this_face = &dfaces[facenum];
 
         if (texinfo[this_face->texinfo].flags & (SURF_WARP | SURF_SKY))
-            return; // non-lit texture
+            goto cleanup; // non-lit texture
 
-        memset(styletable, 0, sizeof(styletable));
+        memset(styletable, 0, sizeof(*styletable) * MAX_LSTYLES);
 
         if (extrasamples) // set with -extra option
             numsamples = 5;
@@ -2314,6 +2317,10 @@ void BuildFacelights(int32_t facenum) {
             VectorAdd(spot, face_patches[facenum]->baselight, spot);
         }
     }
+
+cleanup:
+    free(liteinfo);
+    free(styletable);
 }
 
 /*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.11)
+project(q2tools-220 LANGUAGES C)
+
+set(Q2T_USE_PTHREADS ON CACHE BOOL "compile with pthread support")
+
+if(Q2T_USE_PTHREADS)
+  set(THREADING_OPTION -pthread -DUSE_PTHREADS)
+else()
+  set(THREADING_OPTION -DUSE_SETRLIMIT)
+endif()
+
+add_library(q2tools-i INTERFACE)
+target_compile_options(q2tools-i INTERFACE -fno-common -Wall -Wno-unused-result -Wno-strict-aliasing ${THREADING_OPTION} -DUSE_ZLIB)
+
+add_library(q2tools-220-lib STATIC
+    common/bspfile.c
+    common/cmdlib.c
+    common/l3dslib.c
+    common/lbmlib.c
+    common/llwolib.c
+    common/mathlib.c
+    common/mdfour.c
+    common/polylib.c
+    common/scriplib.c
+    common/threads.c
+    common/trilib.c
+)
+target_include_directories(q2tools-220-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/common)
+
+add_executable(4bsp
+    4bsp/4bsp.c
+    4bsp/brushbsp.c
+    4bsp/csg.c
+    4bsp/faces.c
+    4bsp/leakfile.c
+    4bsp/map.c
+    4bsp/portals.c
+    4bsp/prtfile.c
+    4bsp/textures.c
+    4bsp/tree.c
+    4bsp/writebsp.c
+)
+add_executable(4vis
+    4vis/4vis.c
+    4vis/flow.c
+)
+add_executable(4rad
+    4rad/4rad.c
+    4rad/lightmap.c
+    4rad/patches.c
+    4rad/trace.c
+)
+
+target_link_libraries(4bsp q2tools-i q2tools-220-lib)
+target_link_libraries(4vis q2tools-i q2tools-220-lib)
+target_link_libraries(4rad q2tools-i q2tools-220-lib)


### PR DESCRIPTION
4rad was giving me a lot of issues, compiling with mingw64. failing in a function called __chkstk_ms . turns out using a lot of stack space causes issues with that setup :(. the solution for me to get 4rad running was to reduce stack use by allocating and freeing large stack objects. these operations are very quick and mostly happen with thread based functions. allocating memory for thread work makes sense so I went ahead with that change and another the main entry point and temp buffers for options.

Also included is the cmake I used to build.