### PR TITLE
Incomplete SURF_ALPHATEST support

### DIFF
--- a/src/images.c
+++ b/src/images.c
@@ -278,7 +278,7 @@ void Cmd_Colormap(void) {
             *lump_p++ = c;
     }
 
-    // 66% transparancy table
+    // 66% translucency table
     for (l = 0; l < 255; l++) {
         for (c = 0; c < 255; c++) {
             red       = lbmpalette[c * 3] * 0.33 + lbmpalette[l * 3] * 0.66;
@@ -460,6 +460,7 @@ mipparm_t mipparms[] =
         {"nodraw", SURF_NODRAW, pt_flags},   // for clip textures and trigger textures
         {"hint", SURF_HINT, pt_flags},
         {"skip", SURF_SKIP, pt_flags},
+        {"alphatest", SURF_ALPHATEST, pt_flags}, // binary transparency
 
         {NULL, 0, pt_contents}};
 

--- a/src/map.c
+++ b/src/map.c
@@ -269,9 +269,9 @@ int32_t BrushContents(mapbrush_t *b) {
         }
     }
 
-    // if any side is translucent, mark the contents
+    // if any side is translucent or transparent, mark the contents
     // and change solid to window
-    if (trans & (SURF_TRANS33 | SURF_TRANS66)) {
+    if (trans & (SURF_TRANS33 | SURF_TRANS66 | SURF_ALPHATEST)) {
         contents |= CONTENTS_TRANSLUCENT;
         if (contents & CONTENTS_SOLID) {
             contents &= ~CONTENTS_SOLID;

--- a/src/patches.c
+++ b/src/patches.c
@@ -264,6 +264,7 @@ void CalcTextureReflectivity(void) {
                     a = tex_a / 765.0;
                 } else if (texinfo[i].flags & SURF_TRANS66) {
                     a = tex_a / 382.5;
+                // Do we need something here for SURF_ALPHATEST?
                 } else {
                     a = 1.0;
                 }

--- a/src/qfiles.h
+++ b/src/qfiles.h
@@ -458,6 +458,8 @@ typedef struct
 #define SURF_HINT             0x0100 // make a bsp splitter
 #define SURF_SKIP             0x0200 // ignore surface to make non-closed brushes
 
+#define SURF_ALPHATEST        0x02000000 // binary transparency - used by Q2EX, Q2Pro, KMQ2, etc.
+
 // qb: qbsp types - dnode_tx, dedge_tx, dface_tx, dleaf_tx, dbrushside_tx
 
 typedef struct


### PR DESCRIPTION
## Issue
The new Quake II remaster (henceforth Q2EX) supports an additional surface flag (bit 25, `0x02000000`) for binary transparency, as seen in Q2Pro and KMQuake2. Like SURF_TRANS33 and SURF_TRANS66, this flag needs to be used in conjunction with CONTENTS_TRANSLUCENT in order to actually allow the contained brush to be seen through. 

## Solution
Q2Tools-220 currently automatically flags brushes with faces containing Trans33 and Trans66 as translucent, and this function could be extended to do the same for alphatest.
I have drafted an example of what might need to be done. I don't really do much programming, so I don't completely understand everything involved, which is why this is currently labeled as incomplete and a draft. For example, there are some mentions of the translucency flags in [src/patches.c](https://github.com/qbism/q2tools-220/blob/master/src/patches.c#L263) that I have no clue what they do. I hope though, that as a draft, it explains well enough what should be necessary to accomplish what I am suggesting be added.